### PR TITLE
Improve comparison.md + add complgen

### DIFF
--- a/comparision.md
+++ b/comparision.md
@@ -1,14 +1,14 @@
 Here is the comparison of popular shell completion generators:
 
-| Feature            | [crazy-complete](https://github.com/crazy-complete/crazy-complete) | [argpcomplete](argpcomplete) | [auto-auto-complete](https://codeberg.org/maandree/auto-auto-complete)[^1] | [complete-shell](https://github.com/complete-shell/complete-shell) | [completely](https://github.com/DannyBen/completely) |
-| ------------------ | -------- | -------- | -------- | ---- | ---- |
-| Standalone scripts | yes      | no       | yes      | no   | yes  |
-| Robust scripts     | yes      | yes      | no       | n/a  | no   |
-| Extensible scripts | yes      | yes      | yes      | no   | no   |
-| Bash support       | yes      | yes      | yes      | yes  | yes  |
-| Fish support       | yes      | no       | yes      | no   | no   |
-| Zsh support        | yes      | yes      | yes      | no   | no   |
-| Dependencies       | Python 3 | Python 3 | Python 3 | Bash | Ruby |
+| Feature            | [crazy-complete](https://github.com/crazy-complete/crazy-complete) | [argpcomplete](argpcomplete) | [auto-auto-complete](https://codeberg.org/maandree/auto-auto-complete)[^1] | [complete-shell](https://github.com/complete-shell/complete-shell) | [completely](https://github.com/DannyBen/completely) | [complgen](https://github.com/adaszko/complgen) |
+| ------------------ | -------- | -------- | -------- | ---- | ---- | ---- |
+| Standalone scripts | yes      | no       | yes      | no   | yes  | yes  |
+| Robust scripts     | yes      | yes      | no       | n/a  | no   | yes  |
+| Extensible scripts | yes      | yes      | yes      | no   | no   | yes  |
+| Bash support       | yes      | yes      | yes      | yes  | yes  | yes  |
+| Fish support       | yes      | no       | yes      | no   | no   | yes  |
+| Zsh support        | yes      | yes      | yes      | no   | no   | yes  |
+| Dependencies       | Python 3 | Python 3 | Python 3 | Bash | Ruby | Rust |
 
 [^1]: The domain specific language for this project is insane, have a look
 at the

--- a/comparision.md
+++ b/comparision.md
@@ -1,77 +1,15 @@
-crazy-complete
-==============
+Here is the comparison of popular shell completion generators:
 
-https://github.com/crazy-complete/crazy-complete
+| Feature            | [crazy-complete](https://github.com/crazy-complete/crazy-complete) | [argpcomplete](argpcomplete) | [auto-auto-complete](https://codeberg.org/maandree/auto-auto-complete)[^1] | [complete-shell](https://github.com/complete-shell/complete-shell) | [completely](https://github.com/DannyBen/completely) |
+| ------------------ | -------- | -------- | -------- | ---- | ---- |
+| Standalone scripts | yes      | no       | yes      | no   | yes  |
+| Robust scripts     | yes      | yes      | no       | n/a  | no   |
+| Extensible scripts | yes      | yes      | yes      | no   | no   |
+| Bash support       | yes      | yes      | yes      | yes  | yes  |
+| Fish support       | yes      | no       | yes      | no   | no   |
+| Zsh support        | yes      | yes      | yes      | no   | no   |
+| Dependencies       | Python 3 | Python 3 | Python 3 | Bash | Ruby |
 
-| Feature            | Supported  |
-| ------------------ | ---------- |
-| Standalone scripts | yes        |
-| Robust scripts     | yes        |
-| Extensible scripts | yes        |
-| Bash support       | yes        |
-| Fish support       | yes        |
-| Zsh support        | yes        |
-| Dependencies       | Python 3   |
-
-argpcomplete
-============
-
-https://pypi.org/project/argcomplete/
-
-| Feature            | Supported  |
-| ------------------ | ---------- |
-| Standalone scripts | no         |
-| Robust scripts     | yes        |
-| Extensible scripts | yes        |
-| Bash support       | yes        |
-| Fish support       | no         |
-| Zsh support        | yes        |
-| Dependencies       | Python 3   |
-
-auto-auto-complete
-==================
-
-https://codeberg.org/maandree/auto-auto-complete
-
-| Feature            | Supported  |
-| ------------------ | ---------- |
-| Standalone scripts | yes        |
-| Robust scripts     | no         |
-| Extensible scripts | yes        |
-| Bash support       | yes        |
-| Fish support       | yes        |
-| Zsh support        | yes        |
-| Dependencies       | Python 3   |
-
-Notes: The domain specific language for this project is insane, have a look at the [example](https://codeberg.org/maandree/auto-auto-complete/src/branch/master/doc/example).
-
-complete-shell
-==============
-
-https://github.com/complete-shell/complete-shell
-
-| Feature            | Supported  |
-| ------------------ | ---------- |
-| Standalone scripts | no         |
-| Robust scripts     | n/a        |
-| Extensible scripts | no         |
-| Bash support       | yes        |
-| Fish support       | no         |
-| Zsh support        | no         |
-| Dependencies       | Bash       |
-
-completely
-==========
-
-https://github.com/DannyBen/completely
-
-| Feature            | Supported  |
-| ------------------ | ---------- |
-| Standalone scripts | yes        |
-| Robust scripts     | no         |
-| Extensible scripts | no         |
-| Bash support       | yes        |
-| Fish support       | no         |
-| Zsh support        | no         |
-| Dependencies       | Ruby       |
-
+[^1]: The domain specific language for this project is insane, have a look
+at the
+[example](https://codeberg.org/maandree/auto-auto-complete/src/branch/master/doc/example).


### PR DESCRIPTION
I found the old comparison page hard to read. Putting everything into a single table makes it easier to compare the different completion generators.

I've got a question about the "Robust scripts" and "Extensible scripts" categories. What exactly do they mean? Is this related to the possibility of including shell specific code in the completion (like [this](https://github.com/adaszko/complgen/blob/56bd58aa278a6ddc412c926de15cdd38f4f3c355/examples/specialization.usage#L5-L7) in complgen)?