### PR TITLE
Update docs

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -71,6 +71,26 @@ options:
 Item 1  (Description 1)  Item 2  (Description 2)
 ```
 
+**value_list**
+
+> Complete one or more items from a list of items. Similar to `mount -o`. Arguments
+> with assignable values (`mount -o uid=1000`) aren't supported.
+> Arguments are supplied by adding {"values": ...}
+
+```
+prog: "example"
+options:
+  - option_strings: ["-o"]
+    complete: ["value_list", {"values": ["exec", "noexec"]}]
+```
+
+```
+ ~ > example -o=<TAB>
+exec    noexec
+ ~ > example -o=exec,<TAB>
+exec    noexec
+```
+
 **exec**
 
 > Execute commandline and parse the output.

--- a/documentation.md
+++ b/documentation.md
@@ -35,6 +35,7 @@ options:
     takes_args: <BOOL>
     complete: <COMPLETE ACTION>
     multiple_option: <BOOL>
+    group: <GROUP>
     when: "<CONDITION>"
 [...]
 ```
@@ -45,6 +46,7 @@ options:
 - *takes\_args* (optional): Indicates if the option takes arguments (true or false, default: true)
 - *complete* (optional): The method used to generate possible completions for this option
 - *multiple\_option* (optional): Indicates whether an option can be suggested multiple times (true or false, default: false)
+- *group* (optional): Add this option into the specified group. Multiple flags from the same group cannot be completed at once. Useful for mutually exclusive flags.
 - *when* (optional): Only enable this option if CONDITION evaluates to true
 
 **Defining a Positional Argument**


### PR DESCRIPTION
Features requested in #3 and #5 aren't documented (that's why I tried to request them, I didn't know they were there). This PR tries to document them.

I assume that these features are ready to be considered stable. If they aren't documented **intentionally** (because they cannot be considered stable), please do not merge this PR.

I would appreciate feedback on the documentation I have written (especially on the `value_list` command). Feel free to just push a better explanation to `main` or to this PR if writing a new one would be simpler than fixing mine.

---

Thanks to your feedback in #3 and #5, I was successfully able to port j4-dmenu-desktop's completions to crazy-complete! You can see the resulting YAML file here: https://github.com/enkore/j4-dmenu-desktop/commit/939d6c6de3ee20af3070acf47d056e0c260e0edc Here is the original ZSH completion for reference: https://github.com/enkore/j4-dmenu-desktop/blob/7f0a72eef9671f9497e5279e11ba73d34ff014ae/etc/_j4-dmenu-desktop

I plan to provide generated completions as release artifacts in each release (users can also generate them manually if they so wish). I do not want to include generated stuff in the git repo, so this seems like the best solution.

I cannot overstate how this project is awesome by the way. It is very polished for a `0.0.0` release. I have spend hours sieving through `zshcompsys(1)` and searching for poorly documented completion functions of Fish. And I don't even talk about Bash. Its completion system is so basic that I just gave up on it and implemented only the most basic functionality for j4-dmenu-desktop. I find it nonsensical that you have to implement a whole completion system from the ground up in every Bash compleiton script because of its basic interface.

crazy-complete configuration syntax is much cleaner than complgen's metalanguage. I haven't tried many "competing" completion generators apart from complgen, but I remember that when I was searching for them, I couldn't find anything which would satisfy my needs (some don't support all three shells, some generate pretty fragile completion scripts etc.)

I even wanted to write a "skeleton program" in another language that would use one of these argument handler libraries which support outputting completion scripts. This "skeleton program" wouldn't actually do anything with the flags which would be provided to it, I would have it only for exporting completions. But then I learned that most of these libraries supporting shell completion output call back to the original binary in the completion script, making this approach unusable. I needed a generator that would be able to generate standalone completion scripts.

This project solves pretty much all my problems I had with shell completion. I really hated that I had to make changes in five places in j4-dmenu-desktop's codebase just to add a single flag (argument handling code + --help output + 3 handwritten completion scripts). crazy-complete simplifies the situation a bit.