### PR TITLE
Minor fixes

### DIFF
--- a/crazy_complete/cli.py
+++ b/crazy_complete/cli.py
@@ -2,6 +2,7 @@
 
 import re
 from collections import OrderedDict
+from types import NoneType
 
 from . import algo
 from .errors import CrazyError, CrazyTypeError
@@ -55,10 +56,10 @@ class CommandLine:
         if not isinstance(prog, str):
             raise CrazyTypeError('prog', 'str', prog)
 
-        if not isinstance(parent, (CommandLine, None.__class__)):
+        if not isinstance(parent, (CommandLine, NoneType)):
             raise CrazyTypeError('parent', 'CommandLine|None', parent)
 
-        if not isinstance(help, (str, None.__class__)):
+        if not isinstance(help, (str, NoneType)):
             raise CrazyTypeError('help', 'str|None', help)
 
         if not isinstance(aliases, list):
@@ -142,7 +143,7 @@ class CommandLine:
         if not isinstance(name, str):
             raise CrazyTypeError('name', 'str', name)
 
-        if not isinstance(help, (str, None.__class__)):
+        if not isinstance(help, (str, NoneType)):
             raise CrazyTypeError('help', 'str|None', help)
 
         if self.subcommands:
@@ -414,25 +415,25 @@ class Positional:
             when (str): Specifies a condition for showing this positional.
         '''
 
-        if not isinstance(parent, (CommandLine, None.__class__)):
+        if not isinstance(parent, (CommandLine, NoneType)):
             raise CrazyTypeError('parent', 'CommandLine|None', parent)
 
         if not isinstance(number, int):
             raise CrazyTypeError('number', 'int', number)
 
-        if not isinstance(metavar, (str, None.__class__)):
+        if not isinstance(metavar, (str, NoneType)):
             raise CrazyTypeError('metavar', 'str|None', metavar)
 
-        if not isinstance(help, (str, None.__class__)):
+        if not isinstance(help, (str, NoneType)):
             raise CrazyTypeError('help', 'str|None', help)
 
-        if not isinstance(complete, (list, tuple, None.__class__)):
+        if not isinstance(complete, (list, tuple, NoneType)):
             raise CrazyTypeError('complete', 'list|None', complete)
 
         if not isinstance(repeatable, bool):
             raise CrazyTypeError('repeatable', 'bool', repeatable)
 
-        if not isinstance(when, (str, None.__class__)):
+        if not isinstance(when, (str, NoneType)):
             raise CrazyTypeError('when', 'str|None', when)
 
         if number <= 0:
@@ -522,22 +523,22 @@ class Option:
             Option: The newly added Option object.
         '''
 
-        if not isinstance(parent, (CommandLine, None.__class__)):
+        if not isinstance(parent, (CommandLine, NoneType)):
             raise CrazyTypeError('parent', 'CommandLine|None', parent)
 
         if not isinstance(option_strings, list):
             raise CrazyTypeError('option_strings', 'list', option_strings)
 
-        if not isinstance(metavar, (str, None.__class__)):
+        if not isinstance(metavar, (str, NoneType)):
             raise CrazyTypeError('metavar', 'str|None', metavar)
 
-        if not isinstance(help, (str, None.__class__)):
+        if not isinstance(help, (str, NoneType)):
             raise CrazyTypeError('help', 'str|None', help)
 
-        if not isinstance(complete, (list, tuple, None.__class__)):
+        if not isinstance(complete, (list, tuple, NoneType)):
             raise CrazyTypeError('complete', 'list|None', complete)
 
-        if not isinstance(groups, (list, None.__class__)):
+        if not isinstance(groups, (list, NoneType)):
             raise CrazyTypeError('groups', 'list|None', groups)
 
         if groups is not None:
@@ -557,7 +558,7 @@ class Option:
         if not isinstance(hidden, bool):
             raise CrazyTypeError('hidden', 'bool', hidden)
 
-        if not isinstance(when, (str, None.__class__)):
+        if not isinstance(when, (str, NoneType)):
             raise CrazyTypeError('when', 'str|None', when)
 
         if not option_strings:

--- a/crazy_complete/dictionary_source.py
+++ b/crazy_complete/dictionary_source.py
@@ -14,6 +14,9 @@ def _validate_keys(dictionary, allowed_keys):
         if key not in allowed_keys:
             raise CrazyError(f'Unknown key: {key}')
 
+def _is_empty_or_whitespace(string):
+    return not string.strip()
+
 def dictionary_to_commandline(dictionary, prog=None):
     _validate_keys(dictionary,
         ['prog', 'help', 'aliases', 'abbreviate_commands', 'abbreviate_options',
@@ -126,6 +129,9 @@ def dictionaries_to_commandline(dictionaries):
 
         if not isinstance(dictionary['prog'], str):
             raise CrazyTypeError('prog', 'str', dictionary["prog"])
+
+        if _is_empty_or_whitespace(dictionary['prog']):
+            raise CrazyError('The `prog` field must not be empty')
 
         commandline_tree.add_commandline(dictionary)
 

--- a/crazy_complete/errors.py
+++ b/crazy_complete/errors.py
@@ -1,8 +1,5 @@
 ''' This module contains Exception classes for crazy-complete '''
 
-def _get_class(obj):
-    return str(type(obj)).replace("<class '", '').replace("'>", '')
-
 class CrazyError(Exception):
     '''
     Exception class for handling predictable or expected errors.
@@ -31,7 +28,7 @@ class CrazyTypeError(CrazyError):
 
     def __str__(self):
         return 'Parameter `%s` has an invalid type. Expected types: %s. Received: %r (%s)' % (
-            self.name, self.expected, self.value, _get_class(self.value))
+            self.name, self.expected, self.value, type(self.value).__name__)
 
 class InternalError(Exception):
     '''

--- a/crazy_complete/generation.py
+++ b/crazy_complete/generation.py
@@ -80,7 +80,7 @@ def enhance_commandline(commandline, program_name, config):
 
     commandline.visit_commandlines(lambda c: apply_config(c, config))
     commandline.visit_commandlines(lambda c: add_parsed_when(c))
-    completion_validator.CompletionValidator().validate_commandlines(commandline)
+    completion_validator.CompletionValidator.validate_commandlines(commandline)
     return commandline
 
 def visit_commandlines(completion_class, ctxt, commandline):


### PR DESCRIPTION
The title says it all. Most of the changes in this PR don't change the behavior whatsoever. The only behavior change included in it is a check whether the `prog` variable is an empty string (validation code already verifies that the value of `prog` is `str`, but it doesn't check whether it is empty or not, so an unhandled exception is thrown [here](https://github.com/crazy-complete/crazy-complete/blob/d958de36cedde0a025437cef976ba512a012df5c/crazy_complete/dictionary_source.py#L86) if it's `""`)