### PR TITLE
Use sh instead of bash in build scripts

### DIFF
--- a/completions/alsa/generate.sh
+++ b/completions/alsa/generate.sh
@@ -1,33 +1,33 @@
-#!/bin/bash
+#!/bin/sh
 
-if [[ -x ../../crazy-complete ]]; then
+if [ -x ../../crazy-complete ]; then
   crazy_complete='../../crazy-complete'
-elif which crazy-complete; then
+elif type crazy-complete >/dev/null; then
   crazy_complete=crazy-complete
 else
   echo "No crazy-complete found"
   exit 1
 fi
 
-if [[ $# -eq 0 ]]; then
+if [ $# -eq 0 ]; then
   echo "Usage: $0 {amixer,alsamixer} {bash,fish,zsh}" >&2
   exit 1
-elif [[ $# -eq 1 ]]; then
+elif [ $# -eq 1 ]; then
   echo "Missing argument: [bash, fish, zsh]"
   exit 1
-elif [[ $# -gt 2 ]]; then
+elif [ $# -gt 2 ]; then
   echo "Too many arguments provided" >&2
   exit 1
 fi
 
-[[ "$1" == "amixer" ]] || [[ "$1" == "alsamixer" ]] || {
+[ "$1" = "amixer" ] || [ "$1" = "alsamixer" ] || {
   echo "\$1: invalid argument: $1" >&2
   exit 1
 }
 
-[[ "$2" == "bash" ]] || [[ "$2" == "fish" ]] || [[ "$2" == "zsh" ]] || {
+[ "$2" = "bash" ] || [ "$2" = "fish" ] || [ "$2" = "zsh" ] || {
   echo "\$2: invalid argument: $2" >&2
   exit 1
 }
 
-$crazy_complete --allow-python --include-file $1.$2 $2 $1.yaml
+$crazy_complete --allow-python --include-file "$1.$2" "$2" "$1.yaml"

--- a/completions/fpm/generate.sh
+++ b/completions/fpm/generate.sh
@@ -1,27 +1,27 @@
-#!/bin/bash
+#!/bin/sh
 
-if [[ -x ../../crazy-complete ]]; then
+if [ -x ../../crazy-complete ]; then
   crazy_complete='../../crazy-complete'
   echo "Using development version of crazy-complete" >&2
-elif which crazy-complete; then
+elif type crazy-complete >/dev/null; then
   crazy_complete=crazy-complete
 else
   echo "No crazy-complete found"
   exit 1
 fi
 
-if [[ $# -eq 0 ]]; then
+if [ $# -eq 0 ]; then
   echo "Usage: $0 {bash,fish,zsh} <options>" >&2
   exit 1
 fi
 
-[[ "$1" == "bash" ]] || [[ "$1" == "fish" ]] || [[ "$1" == "zsh" ]] || {
+[ "$1" = "bash" ] || [ "$1" = "fish" ] || [ "$1" = "zsh" ] || {
   echo "$0: \$1: invalid argument: $1" >&2
   exit 1
 }
 
 opts=''
-if [[ "$1" == 'fish' ]]; then
+if [ "$1" = 'fish' ]; then
   # --repeatable-options=False (which is the default) makes the
   # commpletion slower.
   opts='--repeatable-options=True'

--- a/completions/nbfc/generate.sh
+++ b/completions/nbfc/generate.sh
@@ -1,33 +1,33 @@
-#!/bin/bash
+#!/bin/sh
 
-if [[ -x ../../crazy-complete ]]; then
+if [ -x ../../crazy-complete ]; then
   crazy_complete='../../crazy-complete'
-elif which crazy-complete; then
+elif type crazy-complete >/dev/null; then
   crazy_complete=crazy-complete
 else
   echo "No crazy-complete found"
   exit 1
 fi
 
-if [[ $# -eq 0 ]]; then
+if [ $# -eq 0 ]; then
   echo "Usage: $0 {ec_probe,nbfc,nbfc_service} {bash,fish,zsh}" >&2
   exit 1
-elif [[ $# -eq 1 ]]; then
+elif [ $# -eq 1 ]; then
   echo "Missing argument: [bash, fish, zsh]"
   exit 1
-elif [[ $# -gt 2 ]]; then
+elif [ $# -gt 2 ]; then
   echo "Too many arguments provided" >&2
   exit 1
 fi
 
-[[ "$1" == "ec_probe" ]] || [[ "$1" == "nbfc" ]] || [[ "$1" == "nbfc_service" ]] || {
+[ "$1" = "ec_probe" ] || [ "$1" = "nbfc" ] || [ "$1" = "nbfc_service" ] || {
   echo "\$1: invalid argument: $1" >&2
   exit 1
 }
 
-[[ "$2" == "bash" ]] || [[ "$2" == "fish" ]] || [[ "$2" == "zsh" ]] || {
+[ "$2" = "bash" ] || [ "$2" = "fish" ] || [ "$2" = "zsh" ] || {
   echo "\$2: invalid argument: $2" >&2
   exit 1
 }
 
-$crazy_complete $2 $1.yaml
+$crazy_complete "$2" "$1.yaml"

--- a/test/conversion/run.sh
+++ b/test/conversion/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -x -e
 

--- a/test/install-completions.sh
+++ b/test/install-completions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -6,7 +6,7 @@ cd "$(dirname "$0")"
 
 CRAZY_COMPLETE_TEST=./tests/crazy-complete-test
 CRAZY_COMPLETE_TEST_BIN_FILE=/bin/crazy-complete-test
-SHELLS=(bash fish zsh)
+SHELLS="bash fish zsh"
 
 usage() {
   cat << EOF
@@ -16,27 +16,27 @@ Install or uninstall system-wide completions for 'crazy-complete-test'
 EOF
 }
 
-if [[ $# -ne 1 ]]; then
+if [ $# -ne 1 ]; then
   usage
   exit 1
-elif [[ "$1" == 'install' ]]; then
-  cmd='install-completions'
-elif [[ "$1" == 'uninstall' ]]; then
-  cmd='uninstall-completions'
+elif [ "$1" = 'install' ]; then
+  cmd='install_completions'
+elif [ "$1" = 'uninstall' ]; then
+  cmd='uninstall_completions'
 else
   usage
   exit 1
 fi
 
-if [[ $EUID -ne 0 ]]; then
+if [ "$(id -u)" -ne 0 ]; then
   echo 'This script must be run as root' >&2
   exit 1
 fi
 
-if [[ -x ../crazy-complete ]]; then
+if [ -x ../crazy-complete ]; then
   CRAZY_COMPLETE='../crazy-complete'
   printf '%s\n\n' 'Using development version of crazy-complete' >&2
-elif which crazy-complete &>/dev/null; then
+elif type crazy-complete >/dev/null; then
   CRAZY_COMPLETE='crazy-complete'
   printf '%s\n\n' 'Using installed version of crazy-complete' >&2
 else
@@ -44,10 +44,10 @@ else
   exit 1
 fi
 
-install-completions() {
+install_completions() {
   cp -v "$CRAZY_COMPLETE_TEST" "$CRAZY_COMPLETE_TEST_BIN_FILE"
 
-  for SHELL_ in ${SHELLS[@]}; do
+  for SHELL_ in $SHELLS; do
     case "$SHELL_" in
       bash)
         $CRAZY_COMPLETE -i --input-type=python \
@@ -71,10 +71,10 @@ install-completions() {
   done
 }
 
-uninstall-completions() {
+uninstall_completions() {
   rm -vf "$CRAZY_COMPLETE_TEST_BIN_FILE"
 
-  for SHELL_ in ${SHELLS[@]}; do
+  for SHELL_ in $SHELLS; do
     case "$SHELL_" in
       bash) $CRAZY_COMPLETE -u --input-type=python bash "$CRAZY_COMPLETE_TEST";;
       fish) $CRAZY_COMPLETE -u --input-type=python fish "$CRAZY_COMPLETE_TEST";;

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -16,14 +16,14 @@ Usage: $0 [-f|--fast]
 EOF
 }
 
-if (( $# == 1 )); then
-  if [[ "$1" == "-f" ]] || [[ "$1" == "--fast" ]]; then
+if [ $# -eq 1 ]; then
+  if [ "$1" = "-f" ] || [ "$1" = "--fast" ]; then
     TEST_ARGS="$1"
   else
     usage
     exit 1
   fi
-elif (( $# )); then
+elif [ $# -ge 2 ]; then
   usage
   exit 1
 fi
@@ -32,4 +32,5 @@ set -x
 
 ./conversion/run.sh
 ./error_messages/run.py
+# shellcheck disable=SC2086
 ./tests/run.py $TEST_ARGS


### PR DESCRIPTION
Shell scripts used in crazy-complete are simple enough that they can be made compatible with POSIX sh with little to no effort. No special Bash features are used (except a single use of arrays which was easy to replace).

POSIX sh is more widespread and portable. Some distros ship `dash` as their `/bin/sh`, which is faster to initialize than Bash. It is also conceptually simpler, because it lacks nonstandard features (which is both an advantage and a disadvantage depending on how you look at it).

This PR also removes the use of the `which` utility, which may not be installed. It is replaced by `type`, which is a shell builtin (and therefore is guaranteed to work).

Feel free to close this PR if you are happy with Bash.