### PR TITLE
Fix shebangs

### DIFF
--- a/completions/fpm/generate_from_help.py
+++ b/completions/fpm/generate_from_help.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import re
 import sys

--- a/completions/fpm/old/fpm.py
+++ b/completions/fpm/old/fpm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 

--- a/completions/pylint/update_yaml.py
+++ b/completions/pylint/update_yaml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import yaml

--- a/examples/example.py
+++ b/examples/example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 

--- a/misc/find_progs_with_no_completion.py
+++ b/misc/find_progs_with_no_completion.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import re

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from setuptools import setup
 

--- a/test/error_messages/run.py
+++ b/test/error_messages/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 '''
 This script is for checking error messages of cracy-complete.

--- a/test/tests/crazy-complete-test
+++ b/test/tests/crazy-complete-test
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 

--- a/test/tests/run.py
+++ b/test/tests/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
The Python executable may not always be located in `/usr/bin/python3`. See the following example shell session:

```
> python3 -m venv venv
> . ./venv/bin/activate
(venv) > pip install pyyaml pyte pexpect
[cut]
(venv) > ./test/run.sh
[cut]
+ ./tests/run.py
No module named 'pyte'
Please install the missing modules.
Alternatively, you can use --driver=tmux if you have tmux installed
```

The `pyte` and `pexpect` modules are not detected, because the use of `/usr/bin/python3` is hardcoded. The same shell session works without issues under this PR.