### PR TITLE
Make sure the terminal is correctly cleared before running test

### DIFF
--- a/test/tests/pyte_driver.py
+++ b/test/tests/pyte_driver.py
@@ -35,8 +35,8 @@ class PyteTerminal(TerminalBase):
     def send_tab(self):
         self.terminal.send("\t")
     
-    def send_ctrl_c(self):
-        self.terminal.sendcontrol("c")
+    def send_ctrl(self, key):
+        self.terminal.sendcontrol(key)
     
     def _read_output(self):
         try:

--- a/test/tests/shells.py
+++ b/test/tests/shells.py
@@ -52,7 +52,7 @@ class BashShell(ShellBase):
 
 class FishShell(ShellBase):
     def start(self):
-        self.term.start(['fish', '--no-config'], SHELL_ENV)
+        self.term.start(['fish', '--no-config'], SHELL_ENV | {'fish_autosuggestion_enabled': 0})
 
     def set_prompt(self):
         self.term.send_line("clear; function fish_prompt; printf '> '; end")

--- a/test/tests/terminal_base.py
+++ b/test/tests/terminal_base.py
@@ -8,13 +8,15 @@ class TerminalBase:
         return strip_lines(self.get_output())
 
     def clear_screen(self):
-        self.send_ctrl_c()
-        self.send_line('clear')
-
-        result = self.wait_for_text('>', 1, 0.01)
-        if result != '>':
-            # Idk why, but sometime we have to try again
-            self.clear_screen()
+        result = ''
+        while result != '>':
+            # Cancel potentially running task
+            self.send_ctrl("c")
+            # Clear current command line, as fish does not do it on ^C
+            self.send_ctrl("u")
+            self.wait_for_last_line('>', 5, 0.01)
+            self.send_line('clear')
+            result = self.wait_for_text('>', 5, 0.01)
 
     def complete(self, commandline, num_tabs=1, wait=5, expected=None, fast=False):
         self.clear_screen()
@@ -39,3 +41,14 @@ class TerminalBase:
             timeout -= poll_interval
             time.sleep(poll_interval)
         return self.get_output_stripped()
+
+    def wait_for_last_line(self, expected, timeout, poll_interval):
+        expected = expected.rstrip()
+
+        while timeout > 0.0:
+            result = self.get_output_stripped().split('\n')[-1]
+            if result == expected:
+                return True
+            timeout -= poll_interval
+            time.sleep(poll_interval)
+        return False

--- a/test/tests/terminal_base.py
+++ b/test/tests/terminal_base.py
@@ -15,7 +15,9 @@ class TerminalBase:
             # Clear current command line, as fish does not do it on ^C
             self.send_ctrl("u")
             self.wait_for_last_line('>', 5, 0.01)
-            self.send_line('clear')
+            self.send('clear')
+            self.wait_for_last_line('> clear', 5, 0.01)
+            self.send_line('')
             result = self.wait_for_text('>', 5, 0.01)
 
     def complete(self, commandline, num_tabs=1, wait=5, expected=None, fast=False):

--- a/test/tests/tests.yaml
+++ b/test/tests/tests.yaml
@@ -1097,7 +1097,7 @@ bash_expected: |
   --option=   --sub-bar=
   > crazy-complete-test subcommand --
 fish_expected: |
-  > crazy-complete-test subcommand --option
+  > crazy-complete-test subcommand --
   --option  --sub-bar
 zsh_expected: |
   > crazy-complete-test subcommand --
@@ -1112,7 +1112,7 @@ bash_expected: |
   --option=   --sub-bar=
   > crazy-complete-test subcommand --option lastcommand --
 fish_expected: |
-  > crazy-complete-test subcommand --option lastcommand --option
+  > crazy-complete-test subcommand --option lastcommand --
   --option  --sub-bar
 zsh_expected: |
   > crazy-complete-test subcommand --option lastcommand --

--- a/test/tests/tmux_driver.py
+++ b/test/tests/tmux_driver.py
@@ -54,8 +54,8 @@ class TmuxTerminal(TerminalBase):
     def send_tab(self):
         self._run(['send-keys', '-t', self.session, 'Tab'])
 
-    def send_ctrl_c(self):
-        self._run(['send-keys', '-t', self.session, 'C-c'])
+    def send_ctrl(self, key):
+        self._run(['send-keys', '-t', self.session, f'C-{key}'])
 
     def get_output(self):
         return self._run(['capture-pane', '-t', self.session, '-p'])


### PR DESCRIPTION
Disclaimer: I only tested the tmux driver, and I am not absolutely sure that it completely fixed the issue as I did not manage to reproduce it, but I still think that it should help making the tests more robust.

By running  `^U` in addition to `^C`, we make sure that the current prompt is empty before running "clear" on fish. This was (one of?) the reason why sometimes multiple calls to clear were needed.
We also wait for an empty prompt before running "clear" in addition to after, to make sure that the prompt is ready for entering the "clear" command.
And finally, we keep running clear in a loop until the expected output is just an empty prompt, just in case something completely unexpected happens, but his should normally not be needed.

This should get rid of race conditions, producing this kind of errors on overloaded systems:

```diff
--- test/tests/tests.yaml	2026-03-05 10:01:20.000000000 +0000
+++ test/tests/tests.new.yaml	2026-03-06 22:50:32.911223998 +0000
@@ -91,10 +91,14 @@
 description: "Check long option with argument (with space)"
 send: "crazy-complete-test test --arg "
 bash_expected: |
+  > clear
+
+  bash: lear: command not found
   > crazy-complete-test test --arg
```

or:

```diff
--- test/tests/tests.yaml	2026-03-05 10:01:20.000000000 +0000
+++ test/tests/tests.new.yaml	2026-03-07 04:01:28.256218229 +0000
@@ -2008,6 +2008,9 @@
   > crazy-complete-test --directory-relative
   bin/  directory/
 zsh_expected: |
+  > c
+  > lear
+  zsh: command not found: lear
   > crazy-complete-test --directory-relative
   bin/        directory/
```